### PR TITLE
all: follow golangci-lint rules for linters

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -103,4 +103,4 @@ jobs:
           check-latest: true
 
       - name: "Run golangci-lint"
-        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,18 @@
+version: "2"
+run:
+  go: "1.23"
+
 linters:
   enable:
     - "bodyclose"
     - "copyloopvar"
     - "errcheck"
-    - "gci"
-    - "gofumpt"
     - "goheader"
     - "gosec"
-    - "gosimple"
     - "govet"
     - "ineffassign"
     - "nilerr"
+    - "nolintlint"
     - "predeclared"
     - "revive"
     - "staticcheck"
@@ -20,11 +22,15 @@ linters:
     - "unparam"
     - "whitespace"
 
-linters-settings:
-  # Enforces import order in Go source files
-  gci:
-    sections:
-      - "standard"
-      - "default"
-      - "localmodule"
-    custom-order: true
+formatters:
+  enable:
+    - "gci"
+    - "gofumpt"
+  settings:
+    # Enforces import order in Go source files
+    gci:
+      sections:
+        - "standard"
+        - "default"
+        - "localmodule"
+      custom-order: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/joshuasing/golicenser
 
-go 1.24.1
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.8.1

--- a/header_test.go
+++ b/header_test.go
@@ -215,7 +215,11 @@ func TestHeaderCreate(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewHeader err = %v, want err %v", err, tt.wantErr)
 			}
-			if got := h.Create(tt.filename); got != tt.want {
+			header, err := h.Create(tt.filename)
+			if err != nil {
+				t.Errorf("h.Create(%q) err = %v, want nil", header, err)
+			}
+			if got := header; got != tt.want {
 				t.Errorf("h.Create(%q) = %q, want %q", tt.filename, got, tt.want)
 			}
 		})
@@ -324,7 +328,10 @@ func TestHeaderUpdate(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewHeader err = %v, want err %v", err, tt.wantErr)
 			}
-			got, modified := h.Update(tt.filename, tt.existing)
+			got, modified, err := h.Update(tt.filename, tt.existing)
+			if err != nil {
+				t.Errorf("h.Update() err = %v, want nil", err)
+			}
 			if modified != tt.wantModified {
 				t.Errorf("h.Update() modified = %v, want %v",
 					modified, tt.wantModified)


### PR DESCRIPTION
As I am interested in adding `golicenser` to the `golangci-lint` project, we need to make sure the linter follows all guidelines required by golangci-lint.

This also updates golangci-lint to v2.

Linter
 - [x] It must have a valid license (AGPL is not allowed), and the file must contain the required information by the license, ex: author, year, etc.
 - [x] It must use Go version <= 1.23
 - [x] The linter repository must have a CI and tests.
 - [x] It must use [go/analysis](https://golangci-lint.run/contributing/new-linters/).
 - [x] It must have a valid tag, ex: v1.0.0, v0.1.0.
 - [x] It must not contain init().
 - [x] It must not contain panic().
 - [x] It must not contain log.Fatal(), os.Exit(), or similar.
 - [x] It must not modify the AST.
 - [x] It must have tests inside golangci-lint.

Recommendations
- [x] The linter repository should have a readme and linting.
- [x] The linter should be published as a binary (useful to diagnose bug origins).
- [x] The linter repository should have a .gitignore (IDE files, binaries, OS files, etc. should not be committed)
- [x] A tag should never be recreated.
- [x] use main as the default branch name.