### PR TITLE
header: add setting to escape the match template

### DIFF
--- a/cmd/golicenser/golicenser.go
+++ b/cmd/golicenser/golicenser.go
@@ -41,7 +41,7 @@ var (
 	templateFile        string
 	matchTemplate       string
 	matchTemplateFile   string
-	matchTemplateRegexp bool
+	matchTemplateEscape bool
 	author              string
 	authorRegexp        string
 	variables           string
@@ -62,8 +62,8 @@ func setupFlags() {
 		"Match license header template")
 	flag.StringVar(&matchTemplateFile, "match-tmpl-file", "",
 		"Match license header template file (used to detect existing license headers which may be updated)")
-	flag.BoolVar(&matchTemplateRegexp, "match-tmpl-regexp", false,
-		"Whether the provided match template is a regexp expression")
+	flag.BoolVar(&matchTemplateEscape, "match-tmpl-escape", false,
+		"Whether to regexp-escape the match-tmpl")
 	flag.StringVar(&author, "author", "", "Copyright author")
 	flag.StringVar(&authorRegexp, "author-regexp", "",
 		"Regexp to match copyright author (default: match author)")
@@ -142,14 +142,14 @@ var analyzer = &analysis.Analyzer{
 
 		a, err := golicenser.NewAnalyzer(golicenser.Config{
 			Header: golicenser.HeaderOpts{
-				Template:                   template,
-				MatchTemplate:              matchTemplate,
-				MatchTemplateEscapeDisable: matchTemplateRegexp,
-				Author:                     author,
-				AuthorRegexp:               authorRegexp,
-				Variables:                  vars,
-				YearMode:                   yearMode,
-				CommentStyle:               commentStyle,
+				Template:            template,
+				MatchTemplate:       matchTemplate,
+				MatchTemplateEscape: matchTemplateEscape,
+				Author:              author,
+				AuthorRegexp:        authorRegexp,
+				Variables:           vars,
+				YearMode:            yearMode,
+				CommentStyle:        commentStyle,
 			},
 			Exclude:           strings.Split(exclude, ","),
 			MaxConcurrent:     maxConcurrent,

--- a/header.go
+++ b/header.go
@@ -232,14 +232,14 @@ var tmplFuncMap = template.FuncMap{
 
 // HeaderOpts are the options for creating a license header.
 type HeaderOpts struct {
-	Template                   string
-	MatchTemplate              string
-	MatchTemplateEscapeDisable bool
-	Author                     string
-	AuthorRegexp               string
-	Variables                  map[string]any
-	YearMode                   YearMode
-	CommentStyle               CommentStyle
+	Template            string
+	MatchTemplate       string
+	MatchTemplateEscape bool
+	Author              string
+	AuthorRegexp        string
+	Variables           map[string]any
+	YearMode            YearMode
+	CommentStyle        CommentStyle
 }
 
 // NewHeader creates a new header with the given options.
@@ -286,7 +286,7 @@ func NewHeader(opts HeaderOpts) (*Header, error) {
 		if err != nil {
 			return nil, fmt.Errorf("new match template: %w", err)
 		}
-		matcher, err = headerMatcher(mt, !opts.MatchTemplateEscapeDisable, authorRegexp, opts.Variables)
+		matcher, err = headerMatcher(mt, opts.MatchTemplateEscape, authorRegexp, opts.Variables)
 		if err != nil {
 			return nil, fmt.Errorf("create header matcher (with match template): %w", err)
 		}

--- a/header_test.go
+++ b/header_test.go
@@ -281,9 +281,10 @@ func TestHeaderUpdate(t *testing.T) {
 		{
 			name: "change MIT to OpenBSD",
 			header: HeaderOpts{
-				Template:      LicenseOpenBSD,
-				MatchTemplate: LicenseMIT,
-				Author:        "Joshua Sing",
+				Template:            LicenseOpenBSD,
+				MatchTemplate:       LicenseMIT,
+				MatchTemplateEscape: true,
+				Author:              "Joshua Sing",
 			},
 			wantModified: true,
 			existing: `// Copyright (c) 2025 Joshua Sing


### PR DESCRIPTION
Previously we always escaped the match template, unless MatchTemplateEscapeDisable was set to `true`.

This replaces `MatchTemplateEscapeDisable`, as such the `-match-tmpl-regexp` CLI flag has been removed.
A new CLI flag, `-match-tmpl-escape` has been added to enable escape.

I think it makes more sense to do this the opposite way around, and expect a regexp by default and allow the user to enable escaping. If a match template is not provided, we always escape the template value.