### PR TITLE
header: add ability to provide regexps for variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Flags:
         display offending line with this many lines of context (default -1)
   -comment-style string
         Comment style (line, block) (default "line")
+  -copyright-header-matcher string
+        Copyright header matcher regexp (used to detect existence of any copyright header) (default "(?i)copyright")
   -cpuprofile string
         write CPU profile to this file
   -debug string
@@ -94,14 +96,12 @@ Flags:
         print analyzer flags in JSON
   -json
         emit JSON output
-  -match-header-regexp string
-        Match header regexp (used to detect any copyright headers) (default "(?i)copyright")
-  -match-tmpl string
-        Match license header template
-  -match-tmpl-file string
-        Match license header template file (used to detect existing license headers which may be updated)
-  -match-tmpl-regexp
-        Whether the provided match template is a regexp expression
+  -matcher string
+        License header matcher (This is template, when executed it must become valid regexp)
+  -matcher-escape
+        Whether to regexp-escape the matcher
+  -matcher-file string
+        License header matcher file)
   -max-concurrent int
         Maximum concurrent processes to use when processing files (default 32)
   -memprofile string

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Flags:
   -v    no effect (deprecated)
   -var string
         Template variables (e.g. a=Hello,b=Test)
+  -var-regexp string
+        Template variable regexps (e.g. 'a=(Hello|World),b=(?i)test'
   -year-mode string
         Year formatting mode (preserve, preserve-this-year-range, preserve-modified-range, this-year, last-modified, git-range, git-modified-years) (default "preserve")
 ```

--- a/cmd/golicenser/golicenser.go
+++ b/cmd/golicenser/golicenser.go
@@ -44,6 +44,7 @@ var (
 	author                 string
 	authorRegexp           string
 	variables              string
+	variableRegexps        string
 	yearModeStr            string
 	commentStyleStr        string
 	exclude                string
@@ -65,6 +66,8 @@ func init() {
 	flagSet.StringVar(&authorRegexp, "author-regexp", "",
 		"Regexp to match copyright author (default: match author)")
 	flagSet.StringVar(&variables, "var", "", "Template variables (e.g. a=Hello,b=Test)")
+	flagSet.StringVar(&variableRegexps, "var-regexp", "",
+		"Template variable regexps (e.g. 'a=(Hello|World),b=(?i)test'")
 	flagSet.StringVar(&yearModeStr, "year-mode", golicenser.YearMode(0).String(),
 		"Year formatting mode (preserve, preserve-this-year-range, preserve-modified-range, this-year, last-modified, git-range, git-modified-years)")
 	flagSet.StringVar(&commentStyleStr, "comment-style", golicenser.CommentStyle(0).String(),
@@ -116,9 +119,22 @@ var analyzer = &analysis.Analyzer{
 			for _, v := range strings.Split(variables, ",") {
 				parts := strings.SplitN(v, "=", 2)
 				if len(parts) != 2 {
-					log.Fatal("invalid variable:", v)
+					log.Fatal("invalid variable: ", v)
 				}
 				vars[parts[0]] = golicenser.Var{Value: parts[1]}
+			}
+		}
+		if variableRegexps != "" {
+			for _, v := range strings.Split(variableRegexps, ",") {
+				parts := strings.SplitN(v, "=", 2)
+				if len(parts) != 2 {
+					log.Fatal("invalid variable: ", v)
+				}
+				va, ok := vars[parts[0]]
+				if !ok {
+					log.Fatal("regexp for non-existent variable: ", v)
+				}
+				va.Regexp = parts[1]
 			}
 		}
 

--- a/cmd/golicenser/golicenser.go
+++ b/cmd/golicenser/golicenser.go
@@ -101,7 +101,7 @@ var analyzer = &analysis.Analyzer{
 			//nolint:gosec // Reading user-defined file.
 			b, err := os.ReadFile(matcherFile)
 			if err != nil {
-				log.Fatal("read match template file: ", err)
+				log.Fatal("read matcher file: ", err)
 			}
 			matcher = string(b)
 		} else {
@@ -111,14 +111,14 @@ var analyzer = &analysis.Analyzer{
 		}
 
 		// Parse variables
-		vars := make(map[string]any)
+		vars := make(map[string]golicenser.Var)
 		if variables != "" {
 			for _, v := range strings.Split(variables, ",") {
 				parts := strings.SplitN(v, "=", 2)
 				if len(parts) != 2 {
-					log.Fatal("invalid variable: ", v)
+					log.Fatal("invalid variable:", v)
 				}
-				vars[parts[0]] = parts[1]
+				vars[parts[0]] = golicenser.Var{Value: parts[1]}
 			}
 		}
 


### PR DESCRIPTION
Add ability to provide regexps for variables. These will be used to match the variable values when matching license headers.