### PR TITLE
header: fix default variable regexp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project
 _bench/
+.cover
 bin/
 dist/
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ run: build
 
 .PHONY: test
 test:
-	go test ./...
+	go test -v ./...
 
 .PHONY: test-race
 test-race:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,11 @@ run: build
 
 .PHONY: test
 test:
-	go test -v ./...
+	go test -v -coverprofile=.cover ./...
+
+.PHONY: cover
+cover:
+	go tool cover -html .cover
 
 .PHONY: test-race
 test-race:

--- a/cmd/golicenser/golicenser.go
+++ b/cmd/golicenser/golicenser.go
@@ -114,14 +114,14 @@ var analyzer = &analysis.Analyzer{
 		}
 
 		// Parse variables
-		vars := make(map[string]golicenser.Var)
+		vars := make(map[string]*golicenser.Var)
 		if variables != "" {
 			for _, v := range strings.Split(variables, ",") {
 				parts := strings.SplitN(v, "=", 2)
 				if len(parts) != 2 {
 					log.Fatal("invalid variable: ", v)
 				}
-				vars[parts[0]] = golicenser.Var{Value: parts[1]}
+				vars[parts[0]] = &golicenser.Var{Value: parts[1]}
 			}
 		}
 		if variableRegexps != "" {

--- a/header.go
+++ b/header.go
@@ -220,7 +220,7 @@ type Header struct {
 	matcher *regexp.Regexp
 
 	author       string
-	variables    map[string]Var
+	variables    map[string]*Var
 	yearMode     YearMode
 	commentStyle CommentStyle
 }
@@ -246,7 +246,7 @@ type HeaderOpts struct {
 	MatcherEscape bool
 	Author        string
 	AuthorRegexp  string
-	Variables     map[string]Var
+	Variables     map[string]*Var
 	YearMode      YearMode
 	CommentStyle  CommentStyle
 }
@@ -429,7 +429,7 @@ func (h *Header) render(filename, year string) (string, error) {
 	return b.String(), nil
 }
 
-func headerMatcher(tmpl *template.Template, escapeTmpl bool, authorRegexp *regexp.Regexp, variables map[string]Var) (*regexp.Regexp, error) {
+func headerMatcher(tmpl *template.Template, escapeTmpl bool, authorRegexp *regexp.Regexp, variables map[string]*Var) (*regexp.Regexp, error) {
 	m := map[string]string{
 		"author":   "__VAR_author__",
 		"filename": "__VAR_filename__",
@@ -468,7 +468,7 @@ func headerMatcher(tmpl *template.Template, escapeTmpl bool, authorRegexp *regex
 	return regexp.Compile(headerExpr)
 }
 
-func addVariables(m map[string]any, vars map[string]Var) {
+func addVariables(m map[string]any, vars map[string]*Var) {
 	for k, v := range vars {
 		m[k] = v.Value
 	}

--- a/header_test.go
+++ b/header_test.go
@@ -219,7 +219,7 @@ func TestNewHeader(t *testing.T) {
 			header: HeaderOpts{
 				Template: "{{.project}} by {{.person}}",
 				Author:   "test",
-				Variables: map[string]Var{
+				Variables: map[string]*Var{
 					"project": {Value: "project"},
 					"person":  {Value: "person"},
 				},
@@ -230,7 +230,7 @@ func TestNewHeader(t *testing.T) {
 			header: HeaderOpts{
 				Template: "{{.project}} by {{.person}}",
 				Author:   "test",
-				Variables: map[string]Var{
+				Variables: map[string]*Var{
 					"project": {Value: "project", Regexp: "(golicenser|project)"},
 					"person":  {Value: "human", Regexp: "(human|person)"},
 				},
@@ -241,7 +241,7 @@ func TestNewHeader(t *testing.T) {
 			header: HeaderOpts{
 				Template: "{{.project}} by {{.person}}",
 				Author:   "test",
-				Variables: map[string]Var{
+				Variables: map[string]*Var{
 					"project": {Value: "project", Regexp: "(project"},
 					"person":  {Value: "person", Regexp: "person)"},
 				},
@@ -341,7 +341,7 @@ func TestHeaderCreate(t *testing.T) {
 			header: HeaderOpts{
 				Template: "{{.project}} by {{.person}}",
 				Author:   "test",
-				Variables: map[string]Var{
+				Variables: map[string]*Var{
 					"project": {Value: "project"},
 					"person":  {Value: "person"},
 				},
@@ -353,7 +353,7 @@ func TestHeaderCreate(t *testing.T) {
 			header: HeaderOpts{
 				Template: "{{.project}} by {{.person}}",
 				Author:   "test",
-				Variables: map[string]Var{
+				Variables: map[string]*Var{
 					"project": {Value: "project", Regexp: "(golicenser|project)"},
 					"person":  {Value: "human", Regexp: "(human|person)"},
 				},
@@ -461,6 +461,35 @@ func TestHeaderUpdate(t *testing.T) {
 			wantModified: true,
 		},
 		{
+			name: "custom variables",
+			header: HeaderOpts{
+				Template: "Copyright (c) {{.year}} {{.author}}\nProject: {{.project}}, Greet: {{.greet}}",
+				Author:   "Joshua Sing",
+				YearMode: YearModeThisYear,
+				Variables: map[string]*Var{
+					"project": {Value: "project"},
+					"greet":   {Value: "Hello world"},
+				},
+			},
+			existing:     "// Copyright (c) 2024 Joshua Sing\n// Project: project, Greet: Hello world",
+			want:         "// Copyright (c) 2025 Joshua Sing\n// Project: project, Greet: Hello world\n",
+			wantModified: true,
+		},
+		{
+			name: "custom variables with regexp",
+			header: HeaderOpts{
+				Template: "Copyright (c) {{.year}} {{.author}}\nProject: {{.project}}, Greet: {{.greet}}",
+				Author:   "Joshua Sing",
+				Variables: map[string]*Var{
+					"project": {Value: "project"},
+					"greet":   {Value: "Hello world", Regexp: "Hello (.+)"},
+				},
+			},
+			existing:     "// Copyright (c) 2025 Joshua Sing\n// Project: project, Greet: Hello there!",
+			want:         "// Copyright (c) 2025 Joshua Sing\n// Project: project, Greet: Hello world\n",
+			wantModified: true,
+		},
+		{
 			name: "change MIT to OpenBSD",
 			header: HeaderOpts{
 				Template:      LicenseOpenBSD,
@@ -537,7 +566,7 @@ func TestHeaderMatcher(t *testing.T) {
 		name         string
 		matcher      string
 		escape       bool
-		variables    map[string]Var
+		variables    map[string]*Var
 		authorRegexp *regexp.Regexp
 		wantErr      bool
 		matchTests   []matchTest
@@ -574,7 +603,7 @@ func TestHeaderMatcher(t *testing.T) {
 			name:    "custom variables",
 			matcher: "{{.project}} by {{.name}} - Copyright (c) {{.year}} {{.author}}",
 			escape:  true,
-			variables: map[string]Var{
+			variables: map[string]*Var{
 				"project": {Value: "golicenser", Regexp: "golicenser"},
 				"name":    {Value: "joshuasing", Regexp: "joshuasing"},
 			},
@@ -596,7 +625,7 @@ func TestHeaderMatcher(t *testing.T) {
 			name:    "custom variables with regexp",
 			matcher: "{{.project}} by {{.name}} - Copyright (c) {{.year}} {{.author}}",
 			escape:  true,
-			variables: map[string]Var{
+			variables: map[string]*Var{
 				"project": {Value: "golicenser", Regexp: "go-?licenser"},
 				"name":    {Value: "joshuasing", Regexp: "(joshuasing|someone)"},
 			},


### PR DESCRIPTION
Fix a bug that caused the default regexp string for variables to be empty, meaning custom variables without a provided regexp would never be matched.

This bug was caused by `golicenser.Var` being used without a pointer, meaning when `v.Regexp = regexp.QuoteMeta(v.Value)` was set if the regexp was empty, the regex would not actually change for later use.

Additionally, add test coverage to make sure this does not appear again in the future.