### PR TITLE
analysis, header: improve test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ run: build
 
 .PHONY: test
 test:
-	go test -v -coverprofile=.cover ./...
+	go test -coverprofile=.cover ./...
 
 .PHONY: cover
 cover:

--- a/analysis.go
+++ b/analysis.go
@@ -37,7 +37,7 @@ const (
 	analyzerName = "golicenser"
 
 	// DefaultCopyrightHeaderMatcher is the default regexp used to detect the
-	// existence of any copyright header  This will match any header containing
+	// existence of any copyright header. This will match any header containing
 	// "copyright".
 	DefaultCopyrightHeaderMatcher = "(?i)copyright"
 )


### PR DESCRIPTION
Add test coverage for:
- `func newAnalyzer`
- `func ParseYearMode`
- `func YearModeString`
- `func ParseCommentStyle`
- Line to block comment conversions
- `func detectCommentStyle`

Additionally, this fixes a minor bug where block comments were not properly detected or parsed, possibly resulting in incorrect header detection.

Increases total test coverage to `67.4%`:
```
ok      github.com/joshuasing/golicenser        0.154s  coverage: 67.4% of statements
```

The next major parts I want to have test coverage for are last modified and git date detection.