### PR TITLE
analysis: create header missing diagnostics on package pos

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -189,7 +189,7 @@ func (a *analyzer) checkFile(pass *analysis.Pass, file *ast.File) error {
 			return fmt.Errorf("create %s header: %w", filename, err)
 		}
 		pass.Report(analysis.Diagnostic{
-			Pos:      file.FileStart,
+			Pos:      file.Package,
 			Category: analyzerName,
 			Message:  "missing license header",
 			SuggestedFixes: []analysis.SuggestedFix{{

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -54,6 +54,13 @@ func TestAnalyzer(t *testing.T) {
 			t.Fatalf("NewAnalyzer() err = %v", err)
 		}
 
+		// Test with sources containing build directives.
+		t.Run("builddirective", func(t *testing.T) {
+			t.Parallel()
+			packageDir := filepath.Join(analysistest.TestData(), "src/builddirective/")
+			_ = analysistest.Run(t, packageDir, a)
+		})
+
 		// Different header contains a file with a different license header.
 		// This license header should stay as-is and should not be modified.
 		t.Run("differentheader", func(t *testing.T) {

--- a/testdata/src/builddirective/main.go
+++ b/testdata/src/builddirective/main.go
@@ -1,0 +1,3 @@
+//go:build !foo
+
+package main // want "missing license header"

--- a/testdata/src/builddirective/main.go.golden
+++ b/testdata/src/builddirective/main.go.golden
@@ -1,0 +1,5 @@
+// Copyright (c) 2025 Test
+
+//go:build !foo
+
+package main // want "missing license header"

--- a/testdata/src/packagecomment/main.go
+++ b/testdata/src/packagecomment/main.go
@@ -1,3 +1,3 @@
-// Package packagecomment has a package-level doc comment. This comment should // want "missing license header"
+// Package packagecomment has a package-level doc comment. This comment should
 // not affect the generation of a license header above it.
-package packagecomment
+package packagecomment // want "missing license header"

--- a/testdata/src/packagecomment/main.go.golden
+++ b/testdata/src/packagecomment/main.go.golden
@@ -1,5 +1,5 @@
 // Copyright (c) 2025 Test
 
-// Package packagecomment has a package-level doc comment. This comment should // want "missing license header"
+// Package packagecomment has a package-level doc comment. This comment should
 // not affect the generation of a license header above it.
-package packagecomment
+package packagecomment // want "missing license header"


### PR DESCRIPTION
Change the position used in "missing license header" diagnostics to the position of the file's "package" keyword. This makes "// want" comments easier to manage in tests, and I believe it makes the diagnostic more useful and consistent.

Additionally, add an analysis test containing a build directive to reproduce https://github.com/golangci/golangci-lint/pull/5751#issuecomment-2816729890