### PR TITLE
analysis: remove default testdata exclude

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -42,16 +42,9 @@ const (
 	DefaultCopyrightHeaderMatcher = "(?i)copyright"
 )
 
-var (
-	// DefaultMaxConcurrent is the default maximum concurrency to use when
-	// analyzing files.
-	DefaultMaxConcurrent = runtime.GOMAXPROCS(0) * 2
-
-	// DefaultExcludes are the default files to exclude when analyzing.
-	DefaultExcludes = []string{
-		"**/testdata/**", // Exclude testdata directories
-	}
-)
+// DefaultMaxConcurrent is the default maximum concurrency to use when
+// analyzing files.
+var DefaultMaxConcurrent = runtime.GOMAXPROCS(0) * 2
 
 // Config is the golicenser configuration.
 type Config struct {
@@ -95,9 +88,6 @@ func newAnalyzer(cfg Config) (*analyzer, error) {
 	}
 	if cfg.CopyrightHeaderMatcher == "" {
 		cfg.CopyrightHeaderMatcher = DefaultCopyrightHeaderMatcher
-	}
-	if cfg.Exclude == nil {
-		cfg.Exclude = DefaultExcludes
 	}
 
 	a := &analyzer{cfg: cfg}

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -22,7 +22,6 @@ package golicenser
 
 import (
 	"path/filepath"
-	"reflect"
 	"testing"
 	"time"
 
@@ -47,7 +46,6 @@ func TestAnalyzer(t *testing.T) {
 				Author:   "Test",
 				YearMode: YearModeThisYear,
 			},
-			Exclude: []string{},
 		}
 		a, err := NewAnalyzer(cfg)
 		if err != nil {
@@ -97,7 +95,6 @@ func TestAnalyzer(t *testing.T) {
 				Matcher:  "Copyright \\(c\\) {{.year}} Joshua",
 				YearMode: YearModeThisYear,
 			},
-			Exclude: []string{},
 		}
 		a, err := NewAnalyzer(cfg)
 		if err != nil {
@@ -169,9 +166,6 @@ func TestNewAnalyzer(t *testing.T) {
 					t.Errorf("CopyrightHeaderMatcher = %v, want %v",
 						a.cfg.CopyrightHeaderMatcher, DefaultCopyrightHeaderMatcher)
 				}
-				if !reflect.DeepEqual(a.cfg.Exclude, DefaultExcludes) {
-					t.Errorf("Exclude = %v, want %v", a.cfg.Exclude, DefaultExcludes)
-				}
 			},
 		},
 		{
@@ -188,7 +182,6 @@ func TestNewAnalyzer(t *testing.T) {
 				Header: header,
 				Exclude: []string{
 					"/abc/*",
-					"**/testdata/**",
 					"", // empty strings should be ignored
 					"/test/**",
 				},
@@ -196,19 +189,16 @@ func TestNewAnalyzer(t *testing.T) {
 			check: func(t *testing.T, a *analyzer) {
 				t.Helper()
 
-				if l := len(a.excludes); l != 3 {
-					t.Errorf("excludes len = %d, want 3", l)
+				if l := len(a.excludes); l != 2 {
+					t.Errorf("excludes len = %d, want 2", l)
 				}
 				tests := map[string]bool{
-					"afile.go":              false,
-					"/subdir/test":          false,
-					"/abc/":                 true,
-					"/abc/test":             true,
-					"/testdata/":            true,
-					"/testdata/abc":         true,
-					"/subdir/testdata/test": true,
-					"/test/somefile":        true,
-					"/test/":                true,
+					"afile.go":       false,
+					"/subdir/test":   false,
+					"/abc/":          true,
+					"/abc/test":      true,
+					"/test/somefile": true,
+					"/test/":         true,
 				}
 				for path, want := range tests {
 					var excluded bool
@@ -279,7 +269,7 @@ func TestNewAnalyzer(t *testing.T) {
 				Header: header,
 				Exclude: []string{
 					"/abc/*",
-					"**/testdata/*{*",
+					"**/test/*{*",
 				},
 			},
 			wantErr: true,

--- a/cmd/golicenser/golicenser.go
+++ b/cmd/golicenser/golicenser.go
@@ -72,7 +72,7 @@ func init() {
 		"Year formatting mode (preserve, preserve-this-year-range, preserve-modified-range, this-year, last-modified, git-range, git-modified-years)")
 	flagSet.StringVar(&commentStyleStr, "comment-style", golicenser.CommentStyle(0).String(),
 		"Comment style (line, block)")
-	flagSet.StringVar(&exclude, "exclude", strings.Join(golicenser.DefaultExcludes, ","),
+	flagSet.StringVar(&exclude, "exclude", "",
 		"Paths to exclude (doublestar or r!-prefixed regexp, comma-separated)")
 	flagSet.IntVar(&maxConcurrent, "max-concurrent", golicenser.DefaultMaxConcurrent,
 		"Maximum concurrent processes to use when processing files")


### PR DESCRIPTION
Remove the default excludes containing `**/testdata/**` as Go's tooling should exclude testdata automatically.
I am not entirely sure why I ended up excluding it manually, however it is not needed.

Related: https://github.com/golangci/golangci-lint/pull/5751#issuecomment-2816885345
Thanks @ldez