### PR TITLE
analysis: allow running without concurrency

### DIFF
--- a/cmd/golicenser/golicenser.go
+++ b/cmd/golicenser/golicenser.go
@@ -25,6 +25,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
@@ -34,6 +35,10 @@ import (
 )
 
 var flagSet flag.FlagSet
+
+// DefaultMaxConcurrent is the default maximum number of goroutines to use when
+// analyzing files.
+var DefaultMaxConcurrent = runtime.GOMAXPROCS(0) * 2
 
 var (
 	template               string
@@ -74,7 +79,7 @@ func init() {
 		"Comment style (line, block)")
 	flagSet.StringVar(&exclude, "exclude", "",
 		"Paths to exclude (doublestar or r!-prefixed regexp, comma-separated)")
-	flagSet.IntVar(&maxConcurrent, "max-concurrent", golicenser.DefaultMaxConcurrent,
+	flagSet.IntVar(&maxConcurrent, "max-concurrent", DefaultMaxConcurrent,
 		"Maximum concurrent processes to use when processing files")
 	flagSet.StringVar(&copyrightHeaderMatcher, "copyright-header-matcher", golicenser.DefaultCopyrightHeaderMatcher,
 		"Copyright header matcher regexp (used to detect existence of any copyright header)")


### PR DESCRIPTION
golangci-lint handles concurrency internally, meaning we should avoid creating an unnecessary goroutine and instead allow MaxConcurrent to be set to 0, meaning files should be processed synchronously.

This also optimises for when MaxConcurrent is set to 1, since it is the same as using no concurrency and we can skip using goroutines.

cmd/golicenser keeps the previous default of `GOMAXPROCS * 2` for the MaxConcurrent value.

[golangci/golangci-lint@`a314c0e` (#5751)](https://github.com/golangci/golangci-lint/pull/5751/commits/a314c0edeb8b50159bb1b65d21a0483eca9d2f44#diff-6967782eab8e8e2618b4a87bcc794f33230375c741006564ff0aac6b32ef4986R91-R92)